### PR TITLE
Refactor: Remove Windows-specific UI code

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,11 @@
 
 This file documents the major changes made to the MilkDrop3 codebase in the effort to port it to Linux.
 
+## UI and Event Handling Refactoring
+- **Refactored `pluginshell` and `menu`:** Removed Windows-specific dependencies from the `pluginshell` and `menu` classes. This included removing types like `HWND`, `LRESULT`, `RECT`, and DirectX-specific types.
+- **Cross-Platform Input Handling:** Replaced the Windows-specific `MyWindowProc` function with a new `MyKeyHandler` virtual function that uses GLFW key codes, paving the way for cross-platform input handling.
+- **Consolidated Initialization:** Merged the `PluginPreInitialize` function into `PluginInitialize` to streamline the startup process and remove Windows-specific type dependencies (`HINSTANCE`).
+
 ## OpenGL Port and Rendering
 
 - **Core Rendering Pipeline Ported to OpenGL:** The core rendering pipeline has been ported from DirectX to OpenGL. This is a major milestone in the porting effort.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The original MilkDrop codebase was created by Nullsoft. All credit for the origi
 
 This project is currently undergoing a significant refactoring effort to port the original Windows/DirectX codebase to a modern, cross-platform C++ application that can be compiled and run on Linux using OpenGL.
 
+The UI and event-handling components (`pluginshell` and `menu`) have been refactored to remove Windows-specific dependencies and replace them with a cross-platform approach. However, persistent build environment issues are preventing the application from being compiled and tested, so the impact of these changes on the blank screen issue is currently unverified.
+
 The application now compiles and runs, opening a window. However, the screen is currently black, and the rendering pipeline is being actively debugged.
 
 For a detailed list of the major changes that have been completed, see [CHANGELOG.MD](CHANGELOG.MD).

--- a/TODO.MD
+++ b/TODO.MD
@@ -4,16 +4,19 @@ This file outlines the remaining tasks to complete the Linux port of MilkDrop3.
 
 ## High Priority
 
-- **Debug Blank Screen Issue:** The application now compiles and runs, opening a window, but the screen is black. The next step is to debug the rendering pipeline to identify why nothing is being drawn. This will likely involve:
+- **Complete UI and Event Handling Port:** The initial refactoring of `pluginshell` and `menu` has removed the direct Windows API dependencies from the class definitions, but the work is incomplete. The next critical step is to fully implement the cross-platform UI and event handling.
+    - **Implement `MyKeyHandler` Call Site:** The main application loop in `main.cpp` must be updated to set up a GLFW key callback that calls the `MyKeyHandler` function on the `CPlugin` instance. This will reconnect keyboard input.
+    - **Implement Menu Logic:** The `HandleKeydown` function in `menu.cpp` needs to be implemented to process key events for menu navigation.
+    - **Implement Menu Rendering:** The `DrawMenu` function in `menu.cpp` must be implemented to render the menu using OpenGL, as the original GDI-based implementation has been removed.
+    - **Remove Remaining Stubs:** Any remaining UI-related stubs or placeholder functions should be fully implemented or removed.
+
+- **Debug Blank Screen Issue:** With the UI and event handling refactored, the primary focus can return to the blank screen issue. The goal is to get the visualizer to render correctly. This will likely involve:
     - Verifying that the vertex data is being passed to the shaders correctly.
     - Checking the shader compilation and linking for errors.
     - Ensuring that textures are being loaded and bound correctly.
     - Using `glGetError()` to check for OpenGL errors.
 
-- **Remove Windows API Dependencies:** Many files in `vis_milk2/` still use Windows API elements for UI and other functions. These need to be replaced with cross-platform alternatives (e.g., using GLFW for windowing and input) or removed.
-    - **`pluginshell.h` / `pluginshell.cpp`:** Contains the main window procedure (`WindowProc`) and handles Windows messages (e.g., `WM_KEYDOWN`). This needs to be completely refactored for a GLFW-based event loop.
-    - **`menu.h` / `menu.cpp`:** The menu system is based on the Windows API and needs to be replaced, possibly with a simple on-screen menu rendered with OpenGL.
-    - **Various types:** `RECT`, `LRESULT`, `CALLBACK`, `HWND`, `WPARAM`, `LPARAM` need to be removed.
+- **(Partially Complete) Remove Windows API Dependencies:** The core `pluginshell` and `menu` classes have been refactored to remove Windows-specific types from their public interfaces. However, other dependencies may remain elsewhere in the codebase.
 
 ## Medium Priority
 

--- a/code/vis_milk2/menu.cpp
+++ b/code/vis_milk2/menu.cpp
@@ -37,24 +37,6 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assert.h>
 #include "resource.h"
 
-// Virtual-key codes
-#define VK_BACK           0x08
-#define VK_RETURN         0x0D
-#define VK_SHIFT          0x10
-#define VK_CONTROL        0x11
-#define VK_ESCAPE         0x1B
-#define VK_SPACE          0x20
-#define VK_PRIOR          0x21
-#define VK_NEXT           0x22
-#define VK_END            0x23
-#define VK_HOME           0x24
-#define VK_LEFT           0x25
-#define VK_UP             0x26
-#define VK_RIGHT          0x27
-#define VK_DOWN           0x28
-#define VK_INSERT         0x2D
-#define VK_DELETE         0x2E
-
 extern CPlugin *g_plugin;
 
 CMilkMenuItem::CMilkMenuItem()
@@ -198,12 +180,7 @@ void CMilkMenu::AddItem(const char *szName, void *var, MENUITEMTYPE type, const 
 	m_nChildItems++;
 }
 
-void MyMenuTextOut(eFontIndex font_index, const char* str, DWORD color, RECT* pRect, int bCalcRect, RECT* pCalcRect)
-{
-    // Stubbed out for now
-}
-
-void CMilkMenu::DrawMenu(RECT rect, int xR, int yB, int bCalcRect, RECT* pCalcRect)
+void CMilkMenu::DrawMenu()
 {
     // Stubbed out
 }
@@ -222,8 +199,7 @@ void CMilkMenu::OnWaitStringAccept(char *szNewString)
 	pItem->m_nLastCursorPos = g_plugin->m_waitstring.nCursorPos;
 }
 
-LRESULT CMilkMenu::HandleKeydown(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+void CMilkMenu::HandleKeydown(int key)
 {
     // Stubbed out - keyboard handling will be done in main loop
-    return 1;
 }

--- a/code/vis_milk2/menu.h
+++ b/code/vis_milk2/menu.h
@@ -89,8 +89,8 @@ public:
 					float min=0, float max=0, MilkMenuCallbackFnPtr pCallback=NULL,
                     unsigned int wParam=0, unsigned int lParam=0);
 	void	SetParentPointer(CMilkMenu *pParentMenu) { m_pParentMenu = pParentMenu; }
-	LRESULT HandleKeydown(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
-	void	DrawMenu(RECT rect, int xR, int yB, int bCalcRect=0, RECT* pCalcRect=NULL);
+	void	HandleKeydown(int key);
+	void	DrawMenu();
 	void	OnWaitStringAccept(char *szNewString);
     void    EnableItem(const char* szName, bool bEnable);
     CMilkMenuItem* GetCurItem()

--- a/code/vis_milk2/plugin.cpp
+++ b/code/vis_milk2/plugin.cpp
@@ -430,9 +430,9 @@ void CPlugin::MyRenderFn(int redraw)
 void CPlugin::MyRenderUI(int *upper_left_corner_y, int *upper_right_corner_y, int *lower_left_corner_y, int *lower_right_corner_y, int xL, int xR)
 {
 }
-LRESULT CPlugin::MyWindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam)
+
+void CPlugin::MyKeyHandler(int key)
 {
-    return 1;
 }
 void CPlugin::GetSongTitle(char *szSongTitle, int nSize)
 {
@@ -523,7 +523,6 @@ void CPlugin::WaitString_SeekDownOneLine() {}
 void CPlugin::SavePresetAs(char *szNewFile) {}
 void CPlugin::DeletePresetFile(char *szDelFile) {}
 void CPlugin::RenamePresetFile(char *szOldFile, char *szNewFile) {}
-int CPlugin::HandleRegularKey(WPARAM wParam) { return 1; }
 void CPlugin::SeekToPreset(char cStartChar) {}
 void CPlugin::FindValidPresetDir() {}
 void CPlugin::MergeSortPresets(int left, int right) {}

--- a/code/vis_milk2/plugin.h
+++ b/code/vis_milk2/plugin.h
@@ -635,7 +635,7 @@ public:
         virtual void  CleanUpMyDX9Stuff(int final_cleanup);
         virtual void MyRenderFn(int redraw);
         virtual void MyRenderUI(int *upper_left_corner_y, int *upper_right_corner_y, int *lower_left_corner_y, int *lower_right_corner_y, int xL, int xR);
-        virtual LRESULT MyWindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
+        virtual void MyKeyHandler(int key);
         virtual void OnAltK();
 };
 

--- a/code/vis_milk2/pluginshell.cpp
+++ b/code/vis_milk2/pluginshell.cpp
@@ -65,10 +65,6 @@ float     CPluginShell::GetFps()
 {
 	return m_fps;
 };
-HWND      CPluginShell::GetPluginWindow()
-{
-	if (m_lpDX) return (HWND)m_lpDX->GetWindow(); else return NULL;
-};
 int       CPluginShell::GetWidth()
 {
 	if (m_lpDX) return m_lpDX->m_client_width;  else return 0;
@@ -84,10 +80,6 @@ int       CPluginShell::GetCanvasMarginX()
 int       CPluginShell::GetCanvasMarginY()
 {
 	if (m_lpDX) return (m_lpDX->m_client_height - m_lpDX->m_REAL_client_height)/2; else return 0;
-};
-HINSTANCE CPluginShell::GetInstance()
-{
-	return m_hInstance;
 };
 char* CPluginShell::GetPluginsDirPath()
 {
@@ -108,26 +100,6 @@ int       CPluginShell::GetFontHeight(eFontIndex idx)
 int       CPluginShell::GetBitDepth()
 {
 	if (m_lpDX) return m_lpDX->GetBitDepth(); else return 0;
-};
-LPDIRECT3DDEVICE9 CPluginShell::GetDevice()
-{
-	return NULL;
-};
-D3DCAPS9* CPluginShell::GetCaps()
-{
-	return NULL;
-};
-D3DFORMAT CPluginShell::GetBackBufFormat()
-{
-	return (D3DFORMAT)0;
-};
-D3DFORMAT CPluginShell::GetBackBufZFormat()
-{
-	return (D3DFORMAT)0;
-};
-LPD3DXFONT CPluginShell::GetFont(eFontIndex idx)
-{
-	return NULL;
 };
 char* CPluginShell::GetDriverFilename()
 {
@@ -239,7 +211,7 @@ void CPluginShell::CleanUpDirectX()
 	SafeDelete(m_lpDX);
 }
 
-int CPluginShell::PluginPreInitialize(HWND hWinampWnd, HINSTANCE hWinampInstance)
+int CPluginShell::PluginInitialize(void* device, void* d3dpp, void* window, int iWidth, int iHeight)
 {
 	m_start_fullscreen      = 0;
 	m_start_desktop         = 0;
@@ -290,7 +262,6 @@ int CPluginShell::PluginPreInitialize(HWND hWinampWnd, HINSTANCE hWinampInstance
 	m_frame = 0;
 	m_time = 0;
 	m_fps = 60;
-	m_hInstance = hWinampInstance;
 	m_lpDX = NULL;
 
     strcpy(m_szPluginsDirPath, "./");
@@ -337,11 +308,7 @@ int CPluginShell::PluginPreInitialize(HWND hWinampWnd, HINSTANCE hWinampInstance
 	ReadConfig();
 	MyPreInitialize();
 	MyReadConfig();
-	return TRUE;
-}
 
-int CPluginShell::PluginInitialize(void* device, void* d3dpp, void* window, int iWidth, int iHeight)
-{
     if (!InitDirectX(device, d3dpp, window)) return false;
     m_lpDX->m_client_width = iWidth;
     m_lpDX->m_client_height = iHeight;
@@ -477,11 +444,6 @@ void CPluginShell::AlignWaves()
     // Simplified for now
 	memcpy(m_oldwave[0], m_sound.fWaveform[0], sizeof(float)*576);
 	memcpy(m_oldwave[1], m_sound.fWaveform[1], sizeof(float)*576);
-}
-
-LRESULT CPluginShell::PluginShellWindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam)
-{
-	return MyWindowProc(hWnd, uMsg, wParam, lParam);
 }
 
 void CPluginShell::ToggleHelp()

--- a/code/vis_milk2/pluginshell.h
+++ b/code/vis_milk2/pluginshell.h
@@ -70,23 +70,16 @@ public:
     int       GetFrame();
     float     GetTime();
     float     GetFps();
-    HINSTANCE GetInstance();
     char*  GetPluginsDirPath();
     char*  GetConfigIniFile();
 	char*     GetConfigIniFileA();
 protected:
-    HWND         GetPluginWindow();
     int          GetWidth();
     int          GetHeight();
     int          GetBitDepth();
-    LPDIRECT3DDEVICE9  GetDevice();
-    D3DCAPS9*    GetCaps();
-    D3DFORMAT    GetBackBufFormat();
-    D3DFORMAT    GetBackBufZFormat();
     char*        GetDriverFilename();
     char*        GetDriverDescription();
 public:
-    LPD3DXFONT   GetFont(eFontIndex idx);
     int          GetFontHeight(eFontIndex idx);
     CTextManager m_text;
 protected:
@@ -127,7 +120,7 @@ protected:
     virtual void  CleanUpMyDX9Stuff(int final_cleanup) = 0;
     virtual void MyRenderFn(int redraw)  = 0;
     virtual void MyRenderUI(int *upper_left_corner_y, int *upper_right_corner_y, int *lower_left_corner_y, int *lower_right_corner_y, int xL, int xR) = 0;
-    virtual LRESULT MyWindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam) = 0;
+    virtual void MyKeyHandler(int key) = 0;
     virtual void OnAltK() { };
 
     int m_show_help;
@@ -135,7 +128,6 @@ private:
     int          m_frame;
     float        m_time;
     float        m_fps;
-    HINSTANCE    m_hInstance;
     GLContext*   m_lpDX;
     char      m_szPluginsDirPath[260];
     char      m_szConfigIniFile[260];
@@ -188,16 +180,12 @@ private:
 public:
     CPluginShell();
     ~CPluginShell();
-    int  PluginPreInitialize(HWND hWinampWnd, HINSTANCE hWinampInstance);
     int  PluginInitialize(void* device, void* d3dpp, void* window, int iWidth, int iHeight);
     int  PluginRender(unsigned char *pWaveL, unsigned char *pWaveR);
     void PluginQuit();
     void ToggleHelp();
 	void READ_FONT(int n);
 	void WRITE_FONT(int n);
-    static LRESULT WindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
-    static LRESULT DesktopWndProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
-    static LRESULT VJModeWndProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
 private:
     void DrawAndDisplay(int redraw);
     void ReadConfig();
@@ -241,10 +229,6 @@ protected:
 	  bool		m_bTextWindowClassRegistered;
       void* m_vjd3d9; // LPDIRECT3D9
       void* m_vjd3d9_device; // LPDIRECT3DDEVICE9
-public:
-    LRESULT PluginShellWindowProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
-    LRESULT PluginShellDesktopWndProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
-    LRESULT PluginShellVJModeWndProc(HWND hWnd, unsigned uMsg, WPARAM wParam, LPARAM lParam);
 };
 
 #endif


### PR DESCRIPTION
This commit refactors the `pluginshell` and `menu` components to remove dependencies on the Windows API and DirectX.

Key changes:
- Removed Windows-specific types like `HWND`, `LRESULT`, `RECT`, and DirectX types from `pluginshell.h` and `menu.h`.
- Replaced the Windows message loop handler (`MyWindowProc`) with a cross-platform `MyKeyHandler` that uses GLFW key codes.
- Consolidated initialization logic by merging `PluginPreInitialize` into `PluginInitialize`.
- Updated `README.md`, `CHANGELOG.MD`, and `TODO.MD` to reflect the current status of the project.