### PR TITLE
Fix build and add rendering resource members

### DIFF
--- a/code/vis_milk2/main.cpp
+++ b/code/vis_milk2/main.cpp
@@ -33,7 +33,7 @@ static void key_callback(GLFWwindow* window, int key, int scancode, int action, 
     if (action == GLFW_PRESS || action == GLFW_REPEAT)
     {
         // This is a simplified mapping. A more robust solution would be needed for full compatibility.
-        g_plugin->PluginShellWindowProc(NULL, WM_KEYDOWN, key, 0);
+        g_plugin->MyKeyHandler(key);
     }
 }
 

--- a/code/vis_milk2/milkdropfs.cpp
+++ b/code/vis_milk2/milkdropfs.cpp
@@ -113,9 +113,6 @@ bool CPlugin::RenderStringToTitleTexture()	// m_szSongMessage
 	if (m_supertext.szTextW[0]==0)
 		return false;
 
-    LPDIRECT3DDEVICE9 lpDevice = GetDevice();
-    if (!lpDevice)
-        return false;
 
 	wchar_t szTextToDraw[512];
 	swprintf(szTextToDraw, 512, L" %s ", m_supertext.szTextW);
@@ -442,9 +439,6 @@ void CPlugin::RenderFrame(int bRedraw)
 
 	RunPerFrameEquations(code);
 
-    LPDIRECT3DDEVICE9 lpDevice = GetDevice();
-    if (!lpDevice)
-        return;
 
     DrawMotionVectors();
 	DrawCustomShapes();

--- a/code/vis_milk2/plugin.h
+++ b/code/vis_milk2/plugin.h
@@ -522,6 +522,17 @@ public:
         MYVERTEX    m_comp_verts[FCGSX*FCGSY];
         int         m_comp_indices[(FCGSX-2)*(FCGSY-2)*2*3];
 
+        // OpenGL resources
+        unsigned int m_wave_vao;
+        unsigned int m_wave_vbo;
+        unsigned int m_wave_shader_program;
+        unsigned int m_shape_vao;
+        unsigned int m_shape_vbo;
+        unsigned int m_shape_shader_program;
+        unsigned int m_sprite_vao;
+        unsigned int m_sprite_vbo;
+        unsigned int m_sprite_shader_program;
+
         bool		m_bMMX;
         //bool		m_bSSE;
         bool        m_bHasFocus;

--- a/code/vis_milk2/pluginshell.cpp
+++ b/code/vis_milk2/pluginshell.cpp
@@ -167,7 +167,7 @@ int CPluginShell::AllocateDX9Stuff()
 	int ret = AllocateMyDX9Stuff();
 	m_playlist_top_idx = -1;
 	m_text.Finish();
-	m_text.Init(GetDevice(), (IDirect3DTexture9*)m_lpDDSText, 1);
+	//m_text.Init(GetDevice(), (IDirect3DTexture9*)m_lpDDSText, 1);
 	return ret;
 }
 


### PR DESCRIPTION
This commit resolves several build-breaking errors that remained from the initial porting effort.

- Replaced the Windows-specific `PluginShellWindowProc` call in `main.cpp` with the cross-platform `MyKeyHandler`.
- Removed or commented out calls to the DirectX-specific `GetDevice()` function in `milkdropfs.cpp` and `pluginshell.cpp`.

Additionally, this commit adds the necessary OpenGL resource members (VAOs, VBOs, shader programs) to the `CPlugin` class for wave, shape, and sprite rendering. This prepares the codebase for the implementation of the core rendering functions.